### PR TITLE
Bug Fix: ConfigMsgChan buffer gets full without wait, causing message loss

### DIFF
--- a/simapp.go
+++ b/simapp.go
@@ -1027,14 +1027,16 @@ func dispatchGroup(configMsgChan chan configMessage, group *DevGroup, msgOp int)
 	msg.msgType = device_group
 	msg.name = group.Name
 	msg.msgOp = msgOp
+	configMsgChan <- msg
 
 	// Send the message to the channel safely
-	select {
+	/* select {
 	case configMsgChan <- msg:
 		logger.SimappLog.Infoln("Message sent to configMsgChan successfully")
 	default:
 		logger.SimappLog.Errorln("Failed to send message to configMsgChan: channel full or closed")
-	}
+		time.Sleep(1 * time.Second)
+	}*/
 }
 
 func dispatchAllGroups(configMsgChan chan configMessage) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**

> /kind bug fix


**What this PR does / why we need it**:

In scenarios with high message volume or slow consumers, the configMsgChan buffer gets filled. Since the code uses a non-blocking select, it immediately skips sending when the channel is full, resulting in message loss. This is critical in production environments where each config message is important and must not be dropped.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #13

**Test Report Added?**:
> /kind TESTED


**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->

**Special notes for your reviewer**:
